### PR TITLE
Remove deprecated alt_id field from request

### DIFF
--- a/src/provider-google-place-autocomplete.js
+++ b/src/provider-google-place-autocomplete.js
@@ -147,7 +147,7 @@ function _parsePlace (place, prediction) {
 }
 
 // docs: https://developers.google.com/maps/documentation/javascript/places#place_details_requests
-var _place_fields = 'address_component, adr_address, alt_id, formatted_address, geometry, icon, id, name, permanently_closed, photo, place_id, plus_code, scope, type, url, utc_offset, vicinity'.split(/ *, */)
+var _place_fields = 'address_component, adr_address, formatted_address, geometry, icon, id, name, permanently_closed, photo, place_id, plus_code, scope, type, url, utc_offset, vicinity'.split(/ *, */)
 
 GooglePlaceTypeahead.prototype.getAddress = function __protoGooglePlaceTypeaheadGetAddress (prediction, onSuccess, onError) {
   var self = this,


### PR DESCRIPTION
Google has stopped the support for this field. Currently any API call is returning an error about this field is unsupported.

> error_message: "Error while parsing 'fields' parameter: Unsupported field name 'alt_id'. "

I didn't find any official announcement. Just the field was removed from official documentation someday between May 12th and Aug 10th